### PR TITLE
Add jaeger telemetry support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1255,6 +1255,8 @@ dependencies = [
  "pin-project",
  "rand 0.8.3",
  "thiserror",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -1268,6 +1270,7 @@ dependencies = [
  "opentelemetry",
  "thiserror",
  "thrift",
+ "tokio",
 ]
 
 [[package]]
@@ -2456,6 +2459,7 @@ dependencies = [
  "jemallocator",
  "mimalloc",
  "once_cell",
+ "opentelemetry",
  "opentelemetry-jaeger",
  "ormx",
  "paste",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -852,6 +852,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "integer-encoding"
+version = "1.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48dc51180a9b377fd75814d0cc02199c20f8e99433d6762f650d39cdbbd3b56f"
+
+[[package]]
 name = "ipnet"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1234,6 +1240,44 @@ name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "opentelemetry"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91cea1dfd50064e52db033179952d18c770cbc5dfefc8eba45d619357ba3914"
+dependencies = [
+ "async-trait",
+ "futures",
+ "js-sys",
+ "lazy_static",
+ "percent-encoding",
+ "pin-project",
+ "rand 0.8.3",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry-jaeger"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd4984441954f9ebbe3eebdfc6fd4fa95be6400d403171228779b949f3cd918"
+dependencies = [
+ "async-trait",
+ "lazy_static",
+ "opentelemetry",
+ "thiserror",
+ "thrift",
+]
+
+[[package]]
+name = "ordered-float"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "ormx"
@@ -2164,6 +2208,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
+name = "thrift"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6d965454947cc7266d22716ebfd07b18d84ebaf35eec558586bbb2a8cb6b5b"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "log",
+ "ordered-float",
+ "threadpool",
+]
+
+[[package]]
 name = "time"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2329,6 +2395,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99003208b647dae59dcefc49c98aecaa3512fbc29351685d4b9ef23a9218458e"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-serde"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2377,6 +2456,7 @@ dependencies = [
  "jemallocator",
  "mimalloc",
  "once_cell",
+ "opentelemetry-jaeger",
  "ormx",
  "paste",
  "rand 0.8.3",
@@ -2394,6 +2474,7 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "tranquility-http-signatures",
  "tranquility-ratelimit",

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ Use them by compiling the server with one of the following feature flags:
 These features are mutually exclusive  
 If more than one is activated, all selected allocators are compiled in the binary but neither will be actually used  
 
+## Jaeger telemetry
+
+Tranquility supports exporting the information logged via tracing to a jaeger backend via OpenTelemetry  
+To enable this feature, compile Tranquility with the `jaeger` feature
+
 ## Progress
 
 - [ ] Federation

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Use them by compiling the server with one of the following feature flags:
 These features are mutually exclusive  
 If more than one is activated, all selected allocators are compiled in the binary but neither will be actually used  
 
-## Jaeger telemetry
+## Jaeger integration
 
-Tranquility supports exporting the information logged via tracing to a jaeger backend via OpenTelemetry  
-To enable this feature, compile Tranquility with the `jaeger` feature
+Tranquility supports exporting the data logged via tracing to a jaeger instance  
+To enable this feature, compile Tranquility with the `jaeger` feature flag
 
 ## Progress
 

--- a/tranquility/Cargo.toml
+++ b/tranquility/Cargo.toml
@@ -46,6 +46,10 @@ opentelemetry = { version = "0.13", features = ["rt-tokio"], optional = true }
 opentelemetry-jaeger = { version = "0.12", features = ["tokio"], optional = true }
 tracing-opentelemetry = { version = "0.12", optional = true }
 
+# Memory allocators
+jemalloc = { package = "jemallocator", version = "0.3", optional = true }
+mimalloc = { version = "0.1", optional = true }
+
 [dependencies.tranquility-http-signatures]
 path = "../tranquility-http-signatures"
 features = ["reqwest"]
@@ -56,16 +60,6 @@ path = "../tranquility-ratelimit"
 [dependencies.tranquility-types]
 path = "../tranquility-types"
 features = ["activitypub", "webfinger"]
-
-# Memory allocators
-[dependencies.jemalloc]
-package = "jemallocator"
-version = "0.3"
-optional = true
-
-[dependencies.mimalloc]
-version = "0.1"
-optional = true
 
 [features]
 default = ["mastodon-api"]

--- a/tranquility/Cargo.toml
+++ b/tranquility/Cargo.toml
@@ -18,8 +18,6 @@ headers = "0.3"
 hex = "0.4"
 itertools = "0.10"
 once_cell = "1"
-opentelemetry = { version = "0.13", features = ["rt-tokio"], optional = true }
-opentelemetry-jaeger = { version = "0.12", features = ["tokio"], optional = true }
 ormx = { version = "0.7", features = ["postgres"] }
 paste = "1"
 rand = "0.8"
@@ -37,21 +35,16 @@ thiserror = "1"
 tokio = { version = "1", features = ["full", "tracing"] }
 toml = "0.5"
 tracing = { version = "0.1", features = ["attributes"] }
-tracing-opentelemetry = { version = "0.12", optional = true }
 tracing-subscriber = "0.2"
 url = "2"
 uuid = { version = "0.8", features = ["serde", "v4"] }
 validator = { version = "0.13", features = ["derive"] }
 warp = { version = "0.3", features = ["tls"] }
 
-[dependencies.jemalloc]
-package = "jemallocator"
-version = "0.3"
-optional = true
-
-[dependencies.mimalloc]
-version = "0.1"
-optional = true
+# Jaeger/OpenTelemetry (optional)
+opentelemetry = { version = "0.13", features = ["rt-tokio"], optional = true }
+opentelemetry-jaeger = { version = "0.12", features = ["tokio"], optional = true }
+tracing-opentelemetry = { version = "0.12", optional = true }
 
 [dependencies.tranquility-http-signatures]
 path = "../tranquility-http-signatures"
@@ -63,6 +56,16 @@ path = "../tranquility-ratelimit"
 [dependencies.tranquility-types]
 path = "../tranquility-types"
 features = ["activitypub", "webfinger"]
+
+# Memory allocators
+[dependencies.jemalloc]
+package = "jemallocator"
+version = "0.3"
+optional = true
+
+[dependencies.mimalloc]
+version = "0.1"
+optional = true
 
 [features]
 default = ["mastodon-api"]

--- a/tranquility/Cargo.toml
+++ b/tranquility/Cargo.toml
@@ -18,6 +18,7 @@ headers = "0.3"
 hex = "0.4"
 itertools = "0.10"
 once_cell = "1"
+opentelemetry-jaeger = { version = "0.12", optional = true }
 ormx = { version = "0.7", features = ["postgres"] }
 paste = "1"
 rand = "0.8"
@@ -35,6 +36,7 @@ thiserror = "1"
 tokio = { version = "1", features = ["full", "tracing"] }
 toml = "0.5"
 tracing = { version = "0.1", features = ["attributes"] }
+tracing-opentelemetry = { version = "0.12", optional = true }
 tracing-subscriber = "0.2"
 url = "2"
 uuid = { version = "0.8", features = ["serde", "v4"] }
@@ -65,3 +67,4 @@ features = ["activitypub", "webfinger"]
 default = ["mastodon-api"]
 
 mastodon-api = ["tranquility-types/mastodon"]
+jaeger = ["opentelemetry-jaeger", "tracing-opentelemetry"]

--- a/tranquility/Cargo.toml
+++ b/tranquility/Cargo.toml
@@ -18,7 +18,8 @@ headers = "0.3"
 hex = "0.4"
 itertools = "0.10"
 once_cell = "1"
-opentelemetry-jaeger = { version = "0.12", optional = true }
+opentelemetry = { version = "", features = ["rt-tokio"], optional = true }
+opentelemetry-jaeger = { version = "0.12", features = ["tokio"], optional = true }
 ormx = { version = "0.7", features = ["postgres"] }
 paste = "1"
 rand = "0.8"
@@ -67,4 +68,4 @@ features = ["activitypub", "webfinger"]
 default = ["mastodon-api"]
 
 mastodon-api = ["tranquility-types/mastodon"]
-jaeger = ["opentelemetry-jaeger", "tracing-opentelemetry"]
+jaeger = ["opentelemetry", "opentelemetry-jaeger", "tracing-opentelemetry"]

--- a/tranquility/Cargo.toml
+++ b/tranquility/Cargo.toml
@@ -18,7 +18,7 @@ headers = "0.3"
 hex = "0.4"
 itertools = "0.10"
 once_cell = "1"
-opentelemetry = { version = "", features = ["rt-tokio"], optional = true }
+opentelemetry = { version = "0.13", features = ["rt-tokio"], optional = true }
 opentelemetry-jaeger = { version = "0.12", features = ["tokio"], optional = true }
 ormx = { version = "0.7", features = ["postgres"] }
 paste = "1"

--- a/tranquility/src/cli.rs
+++ b/tranquility/src/cli.rs
@@ -43,7 +43,7 @@ fn init_tracing(level: LevelFilter) {
     let subscriber = {
         let jaeger_tracer = opentelemetry_jaeger::new_pipeline()
             .with_service_name(env!("CARGO_PKG_NAME"))
-            .install_simple()
+            .install_batch(opentelemetry::runtime::Tokio)
             .unwrap();
 
         subscriber.with(OpenTelemetryLayer::new(jaeger_tracer))

--- a/tranquility/src/cli.rs
+++ b/tranquility/src/cli.rs
@@ -8,8 +8,14 @@ use {
     },
     argh::FromArgs,
     std::process,
-    tracing_subscriber::filter::LevelFilter,
+    tracing_subscriber::{
+        filter::LevelFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter,
+        Registry,
+    },
 };
+
+#[cfg(feature = "jaeger")]
+use tracing_opentelemetry::OpenTelemetryLayer;
 
 #[derive(FromArgs)]
 #[argh(description = "An ActivityPub server ^_^")]
@@ -25,6 +31,25 @@ pub struct Opts {
     #[argh(switch, short = 'V')]
     /// print the version
     version: bool,
+}
+
+/// Initialise the tracing subscriber
+fn init_tracing(level: LevelFilter) {
+    let subscriber = Registry::default()
+        .with(EnvFilter::default().add_directive(level.into()))
+        .with(fmt::layer());
+
+    #[cfg(feature = "jaeger")]
+    let subscriber = {
+        let jaeger_tracer = opentelemetry_jaeger::new_pipeline()
+            .with_service_name(env!("CARGO_PKG_NAME"))
+            .install_simple()
+            .unwrap();
+
+        subscriber.with(OpenTelemetryLayer::new(jaeger_tracer))
+    };
+
+    subscriber.init();
 }
 
 /// - Initialises the tracing verbosity levels  
@@ -43,7 +68,8 @@ pub async fn run() -> ArcState {
         1 => LevelFilter::DEBUG,
         _ => LevelFilter::TRACE,
     };
-    tracing_subscriber::fmt().with_max_level(level).init();
+
+    init_tracing(level);
 
     let config = crate::config::load(options.config).await;
     let db_pool = crate::database::connection::init_pool(&config.server.database_url)


### PR DESCRIPTION
Adds the ability to export the tracing logs to a jaeger backend 
(merging into the `misc/ormx` branch because it will hit `main` soon™)