### PR TITLE
misc: Changes related to time handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2565,6 +2565,7 @@ dependencies = [
 name = "tranquility-types"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "serde",
  "serde_json",
 ]

--- a/tranquility-types/Cargo.toml
+++ b/tranquility-types/Cargo.toml
@@ -6,10 +6,11 @@ edition = "2018"
 license = "MIT"
 
 [dependencies]
+chrono = { version = "0.4.19", optional = true }
 serde = { version = "1.0.126", features = ["derive"] }
 serde_json = "1.0.64"
 
 [features]
-activitypub = [ ]
+activitypub = ["chrono"]
 mastodon = [ ]
 webfinger = [ ]

--- a/tranquility-types/src/activitypub/mod.rs
+++ b/tranquility-types/src/activitypub/mod.rs
@@ -1,6 +1,5 @@
 use serde_json::{json, Value};
 
-pub const DATE_TIME_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%.3fZ";
 pub const PUBLIC_IDENTIFIER: &str = "https://www.w3.org/ns/activitystreams#Public";
 
 pub const OUTBOX_FOLLOW_COLLECTIONS_TYPE: &str = "OrderedCollection";
@@ -11,65 +10,13 @@ pub fn context_field() -> Value {
     json!(["https://www.w3.org/ns/activitystreams"])
 }
 
-#[inline]
-/// A replacement for `<array>.contains(<value>)` because `.contains()` because, for example, the `.contains()` of `Vec<String>` can't be used with an `&str`  
-fn contains(vec: &[String], value: &str) -> bool {
-    vec.iter().any(|entry| entry == value)
-}
-
-/// Macro that implements the [IsPublic] and [IsUnlisted] trait for an struct
-///
-/// The struct has to have `to` and `cc` fields that can be implicitly converted to an `&[String]` when referenced
-macro_rules! is_public_unlisted_traits {
-    ($($type:ty),+) => {
-        $(
-            impl IsPublic for $type {
-                fn is_public(&self) -> bool {
-                    contains(&self.to, PUBLIC_IDENTIFIER)
-                }
-            }
-
-            impl IsUnlisted for $type {
-                fn is_unlisted(&self) -> bool {
-                    contains(&self.cc, PUBLIC_IDENTIFIER)
-                }
-            }
-        )+
-    }
-}
-
-pub trait IsPublic {
-    /// Everyone is allowed to see the post and should appear in every timeline  
-    fn is_public(&self) -> bool;
-}
-
-pub trait IsUnlisted {
-    /// Everyone is allowed to see the post but it should only appear in the follower's home timelines  
-    fn is_unlisted(&self) -> bool;
-}
-
-is_public_unlisted_traits!(Activity, Object);
-
-pub trait IsPrivate {
-    /// Only followers and/or mentioned users are allowed to see the post and it should only appear in the aforementioned user groups home timelines  
-    fn is_private(&self) -> bool;
-}
-
-impl<T> IsPrivate for T
-where
-    T: IsPublic + IsUnlisted,
-{
-    fn is_private(&self) -> bool {
-        !self.is_public() && !self.is_unlisted()
-    }
-}
-
 pub mod activity;
 pub mod actor;
 pub mod attachment;
 pub mod collection;
 pub mod object;
 pub mod tag;
+pub mod traits;
 
 pub use activity::Activity;
 pub use actor::{Actor, PublicKey};
@@ -77,3 +24,4 @@ pub use attachment::Attachment;
 pub use collection::Collection;
 pub use object::Object;
 pub use tag::Tag;
+pub use traits::{ApPublished, IsPrivate, IsPublic, IsUnlisted};

--- a/tranquility-types/src/activitypub/traits/mod.rs
+++ b/tranquility-types/src/activitypub/traits/mod.rs
@@ -1,0 +1,5 @@
+pub mod privacy;
+pub mod time;
+
+pub use privacy::{IsPrivate, IsPublic, IsUnlisted};
+pub use time::ApPublished;

--- a/tranquility-types/src/activitypub/traits/privacy.rs
+++ b/tranquility-types/src/activitypub/traits/privacy.rs
@@ -1,0 +1,54 @@
+use crate::{
+    activitypub::{Activity, Object, PUBLIC_IDENTIFIER},
+    util::contains,
+};
+
+/// Macro that implements the [IsPublic] and [IsUnlisted] trait for an struct
+///
+/// The struct has to have `to` and `cc` fields that can be implicitly converted to an `&[String]` when referenced
+macro_rules! is_public_unlisted_traits {
+    ($($type:ty),+) => {
+        $(
+            impl IsPublic for $type {
+                fn is_public(&self) -> bool {
+                    contains(&self.to, PUBLIC_IDENTIFIER)
+                }
+            }
+
+            impl IsUnlisted for $type {
+                fn is_unlisted(&self) -> bool {
+                    contains(&self.cc, PUBLIC_IDENTIFIER)
+                }
+            }
+        )+
+    }
+}
+
+/// Trait to check whether the ActivityPub entity is public
+pub trait IsPublic {
+    /// Everyone is allowed to see the post and should appear in every timeline  
+    fn is_public(&self) -> bool;
+}
+
+/// Trait to check whether the ActivityPub entity is unlisted
+pub trait IsUnlisted {
+    /// Everyone is allowed to see the post but it should only appear in the follower's home timelines  
+    fn is_unlisted(&self) -> bool;
+}
+
+is_public_unlisted_traits!(Activity, Object);
+
+/// Trait to check whether the ActivityPub entity is private
+pub trait IsPrivate {
+    /// Only followers and/or mentioned users are allowed to see the post and it should only appear in the aforementioned user groups home timelines  
+    fn is_private(&self) -> bool;
+}
+
+impl<T> IsPrivate for T
+where
+    T: IsPublic + IsUnlisted,
+{
+    fn is_private(&self) -> bool {
+        !self.is_public() && !self.is_unlisted()
+    }
+}

--- a/tranquility-types/src/activitypub/traits/time.rs
+++ b/tranquility-types/src/activitypub/traits/time.rs
@@ -1,0 +1,25 @@
+use {
+    crate::activitypub::{Activity, Object},
+    chrono::{DateTime, FixedOffset, ParseResult},
+};
+
+/// Implement the macro for ActivityPub entities that have a `published` field
+macro_rules! impl_activitypub_published {
+    ($($entity:ty),+) => {
+        $(
+            impl ApPublished for $entity {
+                fn published_parsed(&self) -> chrono::ParseResult<chrono::DateTime<chrono::FixedOffset>> {
+                    DateTime::parse_from_rfc3339(&self.published)
+                }
+            }
+        )+
+    }
+}
+
+/// Trait for parsing the `published` timestamp
+pub trait ApPublished {
+    /// Get the `published` field from ActivityPub entities in a parsed chrono format
+    fn published_parsed(&self) -> ParseResult<DateTime<FixedOffset>>;
+}
+
+impl_activitypub_published!(Activity, Object);

--- a/tranquility-types/src/lib.rs
+++ b/tranquility-types/src/lib.rs
@@ -2,6 +2,7 @@
 #![allow(
     clippy::doc_markdown,
     clippy::struct_excessive_bools,
+    clippy::missing_errors_doc,
     clippy::must_use_candidate
 )]
 
@@ -14,3 +15,5 @@ pub mod webfinger;
 
 #[cfg(test)]
 mod tests;
+
+mod util;

--- a/tranquility-types/src/util.rs
+++ b/tranquility-types/src/util.rs
@@ -1,0 +1,9 @@
+// Otherwise the compiler will complain when the `activitypub` feature is deactivated
+// Since the only code using this function is the ActivityPub code
+#![allow(dead_code)]
+
+#[inline]
+/// A replacement for `<array>.contains(<value>)` because, for example, the `.contains()` of `Vec<String>` can't be used with an `&str`  
+pub fn contains(vec: &[String], value: &str) -> bool {
+    vec.iter().any(|entry| entry == value)
+}

--- a/tranquility/src/activitypub/instantiate.rs
+++ b/tranquility/src/activitypub/instantiate.rs
@@ -1,5 +1,5 @@
 use {
-    super::activitypub_datetime,
+    super::current_datetime,
     crate::{config::Configuration, format_uuid},
     tranquility_types::activitypub::{activity::ObjectField, Activity, Actor, Object, PublicKey},
     uuid::Uuid,
@@ -26,7 +26,7 @@ pub fn activity<T: Into<ObjectField>>(
         actor: owner_url.into(),
 
         object: object.into(),
-        published: activitypub_datetime(),
+        published: current_datetime(),
 
         to,
         cc,
@@ -100,7 +100,7 @@ pub fn object(
         summary: summary.into(),
         content: content.into(),
         sensitive,
-        published: activitypub_datetime(),
+        published: current_datetime(),
 
         attributed_to: owner_url.into(),
 

--- a/tranquility/src/activitypub/mod.rs
+++ b/tranquility/src/activitypub/mod.rs
@@ -1,8 +1,7 @@
 use {
+    chrono::SecondsFormat,
     serde::{Deserialize, Serialize},
-    tranquility_types::activitypub::{
-        Activity, Actor, IsPrivate, IsUnlisted, Object, DATE_TIME_FORMAT,
-    },
+    tranquility_types::activitypub::{Activity, Actor, IsPrivate, IsUnlisted, Object},
 };
 
 #[derive(Clone, Deserialize)]
@@ -39,8 +38,11 @@ pub struct FollowActivity {
     pub approved: bool,
 }
 
-fn activitypub_datetime() -> String {
-    chrono::Utc::now().format(DATE_TIME_FORMAT).to_string()
+/// Get the current timestamp in the RFC 3339 format
+///
+/// ActivityPub technically uses the ISO 8601 format but RFC 3339 should be fine in most cases
+fn current_datetime() -> String {
+    chrono::Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)
 }
 
 /// Extension trait for cleaning objects from potentially malicious HTML


### PR DESCRIPTION
- Replace the time format string with usage of `DateTime::to_rfc3339_opts`
- Change structure of the `activitypub` module of `tranquility_types`
- Create `ApPublished` trait that parses the `published` field of ActivityPub entities with `chrono` (via the `DateTime::parse_from_rfc3339`)