### PR TITLE
(misc): Change TIMESTAMP to TIMESTAMPTZ, add needs declaration to workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   check:
     name: Check
+    needs: fmt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -36,6 +37,7 @@ jobs:
 
   check_all_features:
     name: Check (all features)
+    needs: fmt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -60,6 +62,7 @@ jobs:
 
   check_no_default:
     name: Check (no features)
+    needs: fmt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -84,6 +87,7 @@ jobs:
 
   test:
     name: Test 
+    needs: [ fmt, clippy, check, check_all_features, check_no_default ]
     runs-on: ubuntu-latest
 
     services:
@@ -137,6 +141,7 @@ jobs:
 
   clippy:
     name: Clippy
+    needs: fmt
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/migrations/20210614155427_timestamp_to_timestamptz.sql
+++ b/migrations/20210614155427_timestamp_to_timestamptz.sql
@@ -1,0 +1,21 @@
+ALTER TABLE actors 
+    ALTER created_at TYPE TIMESTAMPTZ USING created_at AT TIME ZONE 'UTC', 
+    ALTER updated_at TYPE TIMESTAMPTZ USING updated_at AT TIME ZONE 'UTC';
+
+ALTER TABLE objects 
+    ALTER created_at TYPE TIMESTAMPTZ USING created_at AT TIME ZONE 'UTC', 
+    ALTER updated_at TYPE TIMESTAMPTZ USING updated_at AT TIME ZONE 'UTC';
+
+ALTER TABLE oauth_applications 
+    ALTER created_at TYPE TIMESTAMPTZ USING created_at AT TIME ZONE 'UTC', 
+    ALTER updated_at TYPE TIMESTAMPTZ USING updated_at AT TIME ZONE 'UTC';
+
+ALTER TABLE oauth_authorizations 
+    ALTER created_at TYPE TIMESTAMPTZ USING created_at AT TIME ZONE 'UTC', 
+    ALTER updated_at TYPE TIMESTAMPTZ USING updated_at AT TIME ZONE 'UTC', 
+    ALTER valid_until TYPE TIMESTAMPTZ USING valid_until AT TIME ZONE 'UTC';
+
+ALTER TABLE oauth_tokens 
+    ALTER created_at TYPE TIMESTAMPTZ USING created_at AT TIME ZONE 'UTC', 
+    ALTER updated_at TYPE TIMESTAMPTZ USING updated_at AT TIME ZONE 'UTC', 
+    ALTER valid_until TYPE TIMESTAMPTZ USING valid_until AT TIME ZONE 'UTC';

--- a/tranquility/sqlx-data.json
+++ b/tranquility/sqlx-data.json
@@ -22,18 +22,18 @@
         {
           "ordinal": 3,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 4,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
         "Left": [
           "Uuid",
-          "Timestamp",
+          "Timestamptz",
           "Int8"
         ]
       },
@@ -44,33 +44,6 @@
         false,
         false
       ]
-    }
-  },
-  "0d92ecaf0a459e35dfb1d8e5617f7ffe4f19e74558b5c97920c89ace24c5d76b": {
-    "query": "\n                UPDATE actors\n                SET actor = $1, username = $2\n                WHERE actor->>'id' = $3\n            ",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Jsonb",
-          "Text",
-          "Text"
-        ]
-      },
-      "nullable": []
-    }
-  },
-  "0db67a3667c10583d3a68255e2b205c948ba9ac5a0ee143ba9f4629ace7cf3fc": {
-    "query": "\n            UPDATE objects\n            SET data = $1\n            WHERE id = $2\n        ",
-    "describe": {
-      "columns": [],
-      "parameters": {
-        "Left": [
-          "Jsonb",
-          "Uuid"
-        ]
-      },
-      "nullable": []
     }
   },
   "11d3f3540d7d667af4c08036c7bc2c624bb5cc23619cbae6f05b04561421af39": {
@@ -95,12 +68,12 @@
         {
           "ordinal": 3,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 4,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
@@ -126,12 +99,12 @@
         {
           "ordinal": 0,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 1,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
@@ -163,8 +136,8 @@
           "Text",
           "Text",
           "Text",
-          "Timestamp",
-          "Timestamp",
+          "Timestamptz",
+          "Timestamptz",
           "Uuid"
         ]
       },
@@ -198,17 +171,17 @@
         {
           "ordinal": 4,
           "name": "valid_until",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 5,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 6,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
@@ -269,12 +242,12 @@
         {
           "ordinal": 7,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 8,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
@@ -330,12 +303,12 @@
         {
           "ordinal": 6,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 7,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 8,
@@ -373,12 +346,12 @@
         {
           "ordinal": 1,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 2,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
@@ -386,7 +359,7 @@
           "Uuid",
           "Uuid",
           "Text",
-          "Timestamp"
+          "Timestamptz"
         ]
       },
       "nullable": [
@@ -404,8 +377,8 @@
         "Left": [
           "Uuid",
           "Jsonb",
-          "Timestamp",
-          "Timestamp",
+          "Timestamptz",
+          "Timestamptz",
           "Uuid"
         ]
       },
@@ -444,17 +417,17 @@
         {
           "ordinal": 5,
           "name": "valid_until",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 6,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 7,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
@@ -534,12 +507,12 @@
         {
           "ordinal": 7,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 8,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
@@ -582,12 +555,12 @@
         {
           "ordinal": 3,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 4,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
@@ -616,9 +589,9 @@
           "Uuid",
           "Uuid",
           "Text",
-          "Timestamp",
-          "Timestamp",
-          "Timestamp",
+          "Timestamptz",
+          "Timestamptz",
+          "Timestamptz",
           "Uuid"
         ]
       },
@@ -677,12 +650,12 @@
         {
           "ordinal": 3,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 4,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
@@ -706,12 +679,12 @@
         {
           "ordinal": 0,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 1,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
@@ -734,7 +707,7 @@
         {
           "ordinal": 0,
           "name": "timestamp!",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
@@ -813,12 +786,12 @@
         {
           "ordinal": 7,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 8,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
@@ -862,12 +835,12 @@
         {
           "ordinal": 3,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 4,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
@@ -894,12 +867,12 @@
         {
           "ordinal": 1,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 2,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
@@ -985,12 +958,12 @@
         {
           "ordinal": 7,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 8,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
@@ -1033,12 +1006,12 @@
         {
           "ordinal": 3,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 4,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
@@ -1093,12 +1066,12 @@
         {
           "ordinal": 6,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 7,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 8,
@@ -1166,12 +1139,12 @@
         {
           "ordinal": 7,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 8,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
@@ -1222,17 +1195,17 @@
         {
           "ordinal": 5,
           "name": "valid_until",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 6,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 7,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
@@ -1294,12 +1267,12 @@
         {
           "ordinal": 7,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 8,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
@@ -1342,18 +1315,18 @@
         {
           "ordinal": 3,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 4,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
         "Left": [
           "Uuid",
-          "Timestamp",
+          "Timestamptz",
           "Int8"
         ]
       },
@@ -1398,17 +1371,17 @@
         {
           "ordinal": 5,
           "name": "valid_until",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 6,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 7,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
@@ -1451,12 +1424,12 @@
         {
           "ordinal": 3,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 4,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
@@ -1498,12 +1471,12 @@
         {
           "ordinal": 3,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 4,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
@@ -1532,50 +1505,6 @@
       "nullable": []
     }
   },
-  "cc6b4a9f05e8a42b768e900af17153bcd8e0ee07e94637bc86940e28818bd871": {
-    "query": "\n                SELECT * FROM objects\n                WHERE id = $1\n            ",
-    "describe": {
-      "columns": [
-        {
-          "ordinal": 0,
-          "name": "id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 1,
-          "name": "owner_id",
-          "type_info": "Uuid"
-        },
-        {
-          "ordinal": 2,
-          "name": "data",
-          "type_info": "Jsonb"
-        },
-        {
-          "ordinal": 3,
-          "name": "created_at",
-          "type_info": "Timestamp"
-        },
-        {
-          "ordinal": 4,
-          "name": "updated_at",
-          "type_info": "Timestamp"
-        }
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid"
-        ]
-      },
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false
-      ]
-    }
-  },
   "d60adcc0f4b55752a6843fdb4224f81968decac60174293ffddd2e792d14cf3d": {
     "query": "UPDATE oauth_tokens SET application_id = $1, actor_id = $2, access_token = $3, refresh_token = $4, valid_until = $5, created_at = $6, updated_at = $7 WHERE id = $8",
     "describe": {
@@ -1586,9 +1515,9 @@
           "Uuid",
           "Text",
           "Text",
-          "Timestamp",
-          "Timestamp",
-          "Timestamp",
+          "Timestamptz",
+          "Timestamptz",
+          "Timestamptz",
           "Uuid"
         ]
       },
@@ -1607,12 +1536,12 @@
         {
           "ordinal": 1,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 2,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
@@ -1621,7 +1550,7 @@
           "Uuid",
           "Text",
           "Text",
-          "Timestamp"
+          "Timestamptz"
         ]
       },
       "nullable": [
@@ -1673,12 +1602,12 @@
         {
           "ordinal": 7,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 8,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
@@ -1726,17 +1655,17 @@
         {
           "ordinal": 4,
           "name": "valid_until",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 5,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 6,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
@@ -1789,18 +1718,18 @@
         {
           "ordinal": 3,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 4,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
         "Left": [
           "Uuid",
-          "Timestamp",
+          "Timestamptz",
           "Int8"
         ]
       },
@@ -1845,17 +1774,17 @@
         {
           "ordinal": 5,
           "name": "valid_until",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 6,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 7,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
@@ -1902,17 +1831,17 @@
         {
           "ordinal": 4,
           "name": "valid_until",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 5,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 6,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
@@ -1971,12 +1900,12 @@
         {
           "ordinal": 7,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 8,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
@@ -2025,17 +1954,17 @@
         {
           "ordinal": 4,
           "name": "valid_until",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 5,
           "name": "created_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         },
         {
           "ordinal": 6,
           "name": "updated_at",
-          "type_info": "Timestamp"
+          "type_info": "Timestamptz"
         }
       ],
       "parameters": {
@@ -2067,8 +1996,8 @@
           "Text",
           "Jsonb",
           "Bool",
-          "Timestamp",
-          "Timestamp",
+          "Timestamptz",
+          "Timestamptz",
           "Uuid"
         ]
       },

--- a/tranquility/src/api/oauth/authorize.rs
+++ b/tranquility/src/api/oauth/authorize.rs
@@ -67,7 +67,7 @@ pub async fn post(state: ArcState, form: Form, query: Query) -> Result<Response,
         application_id: client.id,
         actor_id: actor.id,
         code: authorization_code,
-        valid_until: valid_until.naive_utc(),
+        valid_until,
     }
     .insert(&state.db_pool)
     .await?;

--- a/tranquility/src/api/oauth/token.rs
+++ b/tranquility/src/api/oauth/token.rs
@@ -116,7 +116,7 @@ async fn code_grant(
         actor_id: authorization_code.actor_id,
         access_token,
         refresh_token: None,
-        valid_until: valid_until.naive_utc(),
+        valid_until,
     }
     .insert(&state.db_pool)
     .await?;
@@ -161,7 +161,7 @@ async fn password_grant(
         actor_id: actor.id,
         access_token,
         refresh_token: None,
-        valid_until: valid_until.naive_utc(),
+        valid_until,
     }
     .insert(&state.db_pool)
     .await?;

--- a/tranquility/src/database/actor.rs
+++ b/tranquility/src/database/actor.rs
@@ -1,5 +1,9 @@
 use {
-    crate::error::Error, chrono::NaiveDateTime, ormx::Table, serde_json::Value, sqlx::PgPool,
+    crate::error::Error,
+    chrono::{DateTime, Utc},
+    ormx::Table,
+    serde_json::Value,
+    sqlx::PgPool,
     uuid::Uuid,
 };
 
@@ -18,9 +22,9 @@ pub struct Actor {
     pub remote: bool,
 
     #[ormx(default)]
-    pub created_at: NaiveDateTime,
+    pub created_at: DateTime<Utc>,
     #[ormx(default)]
-    pub updated_at: NaiveDateTime,
+    pub updated_at: DateTime<Utc>,
 }
 
 impl Actor {

--- a/tranquility/src/database/mod.rs
+++ b/tranquility/src/database/mod.rs
@@ -4,7 +4,7 @@
 use {
     crate::{error::Error, map_err},
     async_trait::async_trait,
-    chrono::{NaiveDateTime, Utc},
+    chrono::{DateTime, Utc},
     sqlx::PgPool,
     uuid::Uuid,
 };
@@ -37,10 +37,10 @@ impl<T> InsertExt for T where T: ormx::Insert {}
 
 /// Wrapper struct for the query of the [last_activity_timestamp] function
 struct ObjectTimestamp {
-    timestamp: NaiveDateTime,
+    timestamp: DateTime<Utc>,
 }
 
-impl From<ObjectTimestamp> for NaiveDateTime {
+impl From<ObjectTimestamp> for DateTime<Utc> {
     fn from(timestamp: ObjectTimestamp) -> Self {
         timestamp.timestamp
     }
@@ -51,7 +51,7 @@ impl From<ObjectTimestamp> for NaiveDateTime {
 async fn last_activity_timestamp(
     conn_pool: &PgPool,
     last_activity_id: Option<Uuid>,
-) -> Result<NaiveDateTime, Error> {
+) -> Result<DateTime<Utc>, Error> {
     let last_timestamp = sqlx::query_as!(
         ObjectTimestamp,
         r#"
@@ -63,7 +63,7 @@ async fn last_activity_timestamp(
     .fetch_one(conn_pool)
     .await
     // Either return the current time or convert it via the `Into` trait
-    .map_or_else(|_| Utc::now().naive_local(), Into::into);
+    .map_or_else(|_| Utc::now(), Into::into);
 
     Ok(last_timestamp)
 }

--- a/tranquility/src/database/oauth/application.rs
+++ b/tranquility/src/database/oauth/application.rs
@@ -1,4 +1,8 @@
-use {chrono::NaiveDateTime, ormx::Table, uuid::Uuid};
+use {
+    chrono::{DateTime, Utc},
+    ormx::Table,
+    uuid::Uuid,
+};
 
 #[derive(Clone, Table)]
 #[ormx(id = id, table = "oauth_applications", insertable)]
@@ -16,7 +20,7 @@ pub struct OAuthApplication {
     pub website: String,
 
     #[ormx(default)]
-    pub created_at: NaiveDateTime,
+    pub created_at: DateTime<Utc>,
     #[ormx(default)]
-    pub updated_at: NaiveDateTime,
+    pub updated_at: DateTime<Utc>,
 }

--- a/tranquility/src/database/oauth/authorization.rs
+++ b/tranquility/src/database/oauth/authorization.rs
@@ -1,4 +1,10 @@
-use {crate::error::Error, chrono::NaiveDateTime, ormx::Table, sqlx::PgPool, uuid::Uuid};
+use {
+    crate::error::Error,
+    chrono::{DateTime, Utc},
+    ormx::Table,
+    sqlx::PgPool,
+    uuid::Uuid,
+};
 
 #[derive(Clone, Table)]
 #[ormx(id = id, table = "oauth_authorizations", insertable)]
@@ -11,12 +17,12 @@ pub struct OAuthAuthorization {
 
     #[ormx(get_one(&str))]
     pub code: String,
-    pub valid_until: NaiveDateTime,
+    pub valid_until: DateTime<Utc>,
 
     #[ormx(default)]
-    pub created_at: NaiveDateTime,
+    pub created_at: DateTime<Utc>,
     #[ormx(default)]
-    pub updated_at: NaiveDateTime,
+    pub updated_at: DateTime<Utc>,
 }
 
 impl OAuthAuthorization {

--- a/tranquility/src/database/oauth/token.rs
+++ b/tranquility/src/database/oauth/token.rs
@@ -1,4 +1,8 @@
-use {chrono::NaiveDateTime, ormx::Table, uuid::Uuid};
+use {
+    chrono::{DateTime, Utc},
+    ormx::Table,
+    uuid::Uuid,
+};
 
 #[derive(Clone, Table)]
 #[ormx(id = id, table = "oauth_tokens", insertable)]
@@ -11,10 +15,10 @@ pub struct OAuthToken {
     #[ormx(get_one(&str))]
     pub access_token: String,
     pub refresh_token: Option<String>,
-    pub valid_until: NaiveDateTime,
+    pub valid_until: DateTime<Utc>,
 
     #[ormx(default)]
-    pub created_at: NaiveDateTime,
+    pub created_at: DateTime<Utc>,
     #[ormx(default)]
-    pub updated_at: NaiveDateTime,
+    pub updated_at: DateTime<Utc>,
 }


### PR DESCRIPTION
Multiple smaller changes:

- Switch from `TIMESTAMP` to `TIMESTAMPTZ`
- Add `needs` declaration to workflow jobs to prevent, for example, compile checks from running if the formatting is wrong