### PR TITLE
fix: Fix and downgrade clippy errors

### DIFF
--- a/tranquility-http-signatures/src/lib.rs
+++ b/tranquility-http-signatures/src/lib.rs
@@ -1,5 +1,6 @@
 #![forbid(rust_2018_idioms, unsafe_code)]
-#![deny(clippy::all, clippy::pedantic, missing_docs)]
+#![warn(clippy::all, clippy::pedantic)]
+#![deny(missing_docs)]
 #![allow(clippy::missing_errors_doc, clippy::module_name_repetitions)]
 // Disable this clippy lint, otherwise clippy will complain when compiled in a test environment
 // (for example, with rust-analyzer)

--- a/tranquility-ratelimit/src/lib.rs
+++ b/tranquility-ratelimit/src/lib.rs
@@ -1,5 +1,5 @@
 #![forbid(unsafe_code)]
-#![deny(clippy::all, clippy::pedantic)]
+#![warn(clippy::all, clippy::pedantic)]
 #![allow(clippy::missing_errors_doc, clippy::must_use_candidate)]
 
 //! Ratelimit library based on governor for warp

--- a/tranquility-types/src/lib.rs
+++ b/tranquility-types/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(clippy::all, clippy::pedantic)]
+#![warn(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::doc_markdown,
     clippy::struct_excessive_bools,

--- a/tranquility/src/api/mastodon/convert.rs
+++ b/tranquility/src/api/mastodon/convert.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::filter_map)]
-
 use {
     crate::{
         database::{Actor as DbActor, OAuthApplication, Object as DbObject},

--- a/tranquility/src/main.rs
+++ b/tranquility/src/main.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
-#![deny(clippy::all, clippy::pedantic, rust_2018_idioms)]
+#![warn(clippy::all, clippy::pedantic)]
+#![deny(rust_2018_idioms)]
 #![allow(clippy::doc_markdown, clippy::module_name_repetitions)]
 
 #[macro_use]


### PR DESCRIPTION
It was a mistake to deny compilation when clippy lints fail 

This fixes the new clippy errors introduced with Rust 1.53 and downgrades clippy lints from `deny` to `warn`